### PR TITLE
[Fix] .hyper.js fontFamily settings not working.

### DIFF
--- a/src/syntax.ts
+++ b/src/syntax.ts
@@ -62,7 +62,5 @@ export const constructSyntax = (dokiTheme: DokiTheme): StringDictonary<any> => {
     backgroundColor: "#00000000",
     borderColor: dokiTheme.colors.borderColor,
     selectionColor: `${dokiTheme.colors.selectionBackground}55`,
-    fontFamily:
-      '"Victor Mono", Menlo, "DejaVu Sans Mono", Consolas, "Lucida Console", monospace',
   };
 };


### PR DESCRIPTION
I noticed that "fontFamily" section of config file .hyper.js not working, so I search for these issues.
Here is what I found: [https://github.com/vercel/hyper/issues/3343#issuecomment-451235240](https://github.com/vercel/hyper/issues/3343#issuecomment-451235240). Then I realize these issues may be caused by the theme.
I check out the code of [https://github.com/defringe/verminal](https://github.com/defringe/verminal) and seems we shouldn't define the section "fontFamily" in the file "src/syntax.ts".
This is what theme verminal do: [https://github.com/defringe/verminal/blob/master/index.js#L62](https://github.com/defringe/verminal/blob/master/index.js#L62)